### PR TITLE
Reducing duplicate code.

### DIFF
--- a/indicator-fast-scroll/src/main/java/com/reddit/indicatorfastscroll/FastScrollerThumbView.kt
+++ b/indicator-fast-scroll/src/main/java/com/reddit/indicatorfastscroll/FastScrollerThumbView.kt
@@ -146,20 +146,13 @@ class FastScrollerThumbView @JvmOverloads constructor(
   ) {
     val thumbTargetY = indicatorCenterY.toFloat() - (thumbView.measuredHeight / 2)
     thumbAnimation.animateToFinalPosition(thumbTargetY)
-
-    when (indicator) {
-      is FastScrollItemIndicator.Text -> {
-        textView.isVisible = true
-        iconView.isVisible = false
-
-        textView.text = indicator.text
-      }
-      is FastScrollItemIndicator.Icon -> {
-        textView.isVisible = false
-        iconView.isVisible = true
-
-        iconView.setImageResource(indicator.iconRes)
-      }
+    
+    textView.isVisible = indicator is FastScrollItemIndicator.Text
+    iconView.isVisible = !textView.isVisible
+    
+    when (textView.isVisible) {
+      true -> textView.text = indicator.text
+      false -> iconView.setImageResource(indicator.iconRes)
     }
   }
 }


### PR DESCRIPTION
I have moved the `isVisible` declaration outside the switch to enhance readability and reduce duplicate code. Since `iconView` is only true when `textView` isn't the assignment of `iconView.isVisible` is the inverse of `textView.isVisible`.